### PR TITLE
[comp 512][a1][justfile] install and run jars instead of class path

### DIFF
--- a/boxes/comp_512/a1/justfile
+++ b/boxes/comp_512/a1/justfile
@@ -20,8 +20,10 @@ run-rmi: build-shared
 
 # start a server
 run-server rmi_object: build-server
-    java -cp server/build/classes/java/main:shared/build/classes/java/main server.rmi.RMIResourceManager {{rmi_object}}
+    ./gradlew :server:installDist
+    ./server/build/install/server/bin/server {{rmi_object}}
 
 # start a client
 run-client hostname rmi_object: build-client
-    java -cp client/build/classes/java/main:shared/build/classes/java/main client.RMIClient {{hostname}} {{rmi_object}}
+    ./gradlew :client:installDist
+    ./client/build/install/client/bin/client {{hostname}} {{rmi_object}}

--- a/boxes/comp_512/a1/justfile
+++ b/boxes/comp_512/a1/justfile
@@ -1,18 +1,18 @@
 # build all packages
 build-all:
-    ./gradlew build
+    ./gradlew clean build
 
 # build the server app
 build-server:
-    ./gradlew :server:build
+    ./gradlew :server:clean build
 
 # build the client app
 build-client:
-    ./gradlew :client:build
+    ./gradlew :client:clean build
 
 # build the shared library
 build-shared:
-    ./gradlew :shared:build
+    ./gradlew :shared:clean build
 
 # start the rmi registry
 run-rmi: build-shared


### PR DESCRIPTION

## Summary:
calling class paths when running can be problematic if we eventually want to add external libraries

instead, create the jar of our executable, and run that

## Test Plan:
it builds and runs
just build-all

just run-server Resources
just run-client localhost Resources
